### PR TITLE
Added `INamer` and defaulted everything to snake case

### DIFF
--- a/source/Ocl.sln.DotSettings
+++ b/source/Ocl.sln.DotSettings
@@ -245,6 +245,7 @@
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=lifecycles/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=liveness/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Migrator/@EntryIndexedValue">True</s:Boolean>
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=Namers/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Nupkg/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=Octofront/@EntryIndexedValue">True</s:Boolean>
 	<s:Boolean x:Key="/Default/UserDictionary/Words/=redirector/@EntryIndexedValue">True</s:Boolean>

--- a/source/Ocl/Converters/DefaultAttributeOclConverter.cs
+++ b/source/Ocl/Converters/DefaultAttributeOclConverter.cs
@@ -8,6 +8,6 @@ namespace Octopus.Ocl.Converters
             => OclAttribute.IsSupportedValueType(type);
 
         protected override IOclElement ConvertInternal(OclConversionContext context, string name, object obj)
-            => new OclAttribute(GetName(name, obj), obj);
+            => new OclAttribute(GetName(context, name, obj), obj);
     }
 }

--- a/source/Ocl/Converters/DefaultBlockOclConverter.cs
+++ b/source/Ocl/Converters/DefaultBlockOclConverter.cs
@@ -12,7 +12,7 @@ namespace Octopus.Ocl.Converters
 
         protected override IOclElement ConvertInternal(OclConversionContext context, string name, object obj)
             => new OclBlock(
-                GetName(name, obj),
+                GetName(context, name, obj),
                 GetLabels(obj),
                 GetElements(obj, context)
             );

--- a/source/Ocl/Converters/OclConverter.cs
+++ b/source/Ocl/Converters/OclConverter.cs
@@ -14,8 +14,8 @@ namespace Octopus.Ocl.Converters
 
         protected abstract IOclElement ConvertInternal(OclConversionContext context, string name, object obj);
 
-        protected virtual string GetName(string name, object obj)
-            => name;
+        protected virtual string GetName(OclConversionContext context, string name, object obj)
+            => context.Namer.FormatName(name);
 
         protected virtual IEnumerable<IOclElement> GetElements(object obj, IEnumerable<PropertyInfo> properties, OclConversionContext context)
         {

--- a/source/Ocl/Namers/IOclNamer.cs
+++ b/source/Ocl/Namers/IOclNamer.cs
@@ -1,0 +1,7 @@
+namespace Octopus.Ocl.Namers
+{
+    public interface IOclNamer
+    {
+        string FormatName(string name);
+    }
+}

--- a/source/Ocl/Namers/IOclNamer.cs
+++ b/source/Ocl/Namers/IOclNamer.cs
@@ -1,7 +1,23 @@
+using System.Collections.Generic;
+using System.Reflection;
+
 namespace Octopus.Ocl.Namers
 {
     public interface IOclNamer
     {
+        /// <summary>
+        /// Formats a name to something OCL friendly
+        /// </summary>
+        /// <param name="name">The name of the element</param>
+        /// <returns>The name to be written out to the OCL document</returns>
         string FormatName(string name);
+
+        /// <summary>
+        /// Get the corresponding property for the given name
+        /// </summary>
+        /// <param name="name">The OCL representation of the name</param>
+        /// <param name="properties">The available properties</param>
+        /// <returns>The property that is the best match for the name, otherwise null if no match is found</returns>
+        PropertyInfo? GetProperty(string name, IReadOnlyCollection<PropertyInfo> properties);
     }
 }

--- a/source/Ocl/Namers/SnakeCaseOclNamer.cs
+++ b/source/Ocl/Namers/SnakeCaseOclNamer.cs
@@ -1,0 +1,13 @@
+using System;
+using System.Text.RegularExpressions;
+
+namespace Octopus.Ocl.Namers
+{
+    public class SnakeCaseOclNamer : IOclNamer
+    {
+        public string FormatName(string name)
+            => Regex.Replace(name, "([a-z])([A-Z])", "$1_$2")
+                .Replace(" ", "_")
+                .ToLower();
+    }
+}

--- a/source/Ocl/Namers/SnakeCaseOclNamer.cs
+++ b/source/Ocl/Namers/SnakeCaseOclNamer.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
 using System.Text.RegularExpressions;
 
 namespace Octopus.Ocl.Namers
@@ -9,5 +12,15 @@ namespace Octopus.Ocl.Namers
             => Regex.Replace(name, "([a-z])([A-Z])", "$1_$2")
                 .Replace(" ", "_")
                 .ToLower();
+
+        public PropertyInfo? GetProperty(string name, IReadOnlyCollection<PropertyInfo> properties)
+        {
+            var nameWithoutUnderscores = name.Replace("_", "");
+            var matches = properties.Where(p => p.Name.Equals(nameWithoutUnderscores, StringComparison.OrdinalIgnoreCase)).ToArray();
+            if(matches.Length > 1)
+                throw new OclException($"Multiple properties match the name '{name}': {string.Join(", ", matches.Select(m => m.Name))}");
+
+            return matches.FirstOrDefault();
+        }
     }
 }

--- a/source/Ocl/OclConversionContext.cs
+++ b/source/Ocl/OclConversionContext.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using Octopus.Ocl.Converters;
+using Octopus.Ocl.Namers;
 
 namespace Octopus.Ocl
 {
@@ -21,7 +22,10 @@ namespace Octopus.Ocl
                         new DefaultBlockOclConverter()
                     })
                 .ToArray();
+            Namer = options.Namer;
         }
+
+        public IOclNamer Namer { get; }
 
         public IEnumerable<IOclElement> ToElements(string name, object? value)
         {

--- a/source/Ocl/OclSerializerOptions.cs
+++ b/source/Ocl/OclSerializerOptions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using Octopus.Ocl.Namers;
 
 namespace Octopus.Ocl
 {
@@ -12,5 +13,6 @@ namespace Octopus.Ocl
         public int IndentDepth { get; set; } = 4;
         public string DefaultHeredocTag { get; set; } = "EOT";
         public List<IOclConverter> Converters { get; set; } = new List<IOclConverter>();
+        public IOclNamer Namer { get; set; } = new SnakeCaseOclNamer();
     }
 }

--- a/source/Tests/ComplexDocument/ComplexDocumentSerializationFixture.Serialization.approved.txt
+++ b/source/Tests/ComplexDocument/ComplexDocumentSerializationFixture.Serialization.approved.txt
@@ -1,11 +1,11 @@
 inline_script_action "Simple Script Action" {
-    Roles = ["web-server"]
+    roles = ["web-server"]
     syntax = "PowerShell"
     body = "Write-Host 'Hi'"
 }
 
 rolling "Rolling Step" {
-    Roles = ["role1", "role2"]
+    roles = ["role1", "role2"]
 
     deploy_to_iis "Deploy Website" {
         apppool_framework = "v4.0"

--- a/source/Tests/ComplexDocument/ComplexDocumentSerializationFixture.cs
+++ b/source/Tests/ComplexDocument/ComplexDocumentSerializationFixture.cs
@@ -90,7 +90,7 @@ namespace Tests.ComplexDocument
                 .Be(
                     new OclDocument
                     {
-                        new OclAttribute("Name", "MyStep"),
+                        new OclAttribute("name", "MyStep"),
                         new OclBlock("decisive", new[] { "run" }),
                         new OclBlock("take_no", new[] { "sit" })
                     }

--- a/source/Tests/ComplexDocument/DeploymentActionOclConverter.cs
+++ b/source/Tests/ComplexDocument/DeploymentActionOclConverter.cs
@@ -11,7 +11,7 @@ namespace Tests.ComplexDocument
         public override bool CanConvert(Type type)
             => typeof(DeploymentAction).IsAssignableFrom(type);
 
-        protected override string GetName(string name, object obj)
+        protected override string GetName(OclConversionContext context, string name, object obj)
             => ((DeploymentAction)obj).Type.Replace(" ", "_").ToLower();
 
         protected override IEnumerable<string> GetLabels(object obj)

--- a/source/Tests/Converters/BlockOclConverterFixture.cs
+++ b/source/Tests/Converters/BlockOclConverterFixture.cs
@@ -15,7 +15,7 @@ namespace Tests.Converters
             var context = new OclConversionContext(new OclSerializerOptions());
             var data = new object();
             var result = (OclBlock)new DefaultBlockOclConverter().ToElements(context, "Test", data).Single();
-            result.Name.Should().Be("Test");
+            result.Name.Should().Be("test");
         }
 
         [Test]
@@ -30,7 +30,7 @@ namespace Tests.Converters
             var result = (OclBlock)new DefaultBlockOclConverter().ToElements(context, "Test", data).Single();
             result.First()
                 .Should()
-                .BeEquivalentTo(new OclAttribute("MyProp", "MyValue"));
+                .BeEquivalentTo(new OclAttribute("my_prop", "MyValue"));
         }
 
         [Test]
@@ -43,7 +43,7 @@ namespace Tests.Converters
                 .Be(
                     new OclBlock("Test")
                     {
-                        new OclAttribute("MyProp", "MyValue")
+                        new OclAttribute("my_prop", "MyValue")
                     }
                 );
         }

--- a/source/Tests/Converters/DefaultAttributeOclConverterFixture.cs
+++ b/source/Tests/Converters/DefaultAttributeOclConverterFixture.cs
@@ -14,7 +14,7 @@ namespace Tests.Converters
         {
             var context = new OclConversionContext(new OclSerializerOptions());
             var result = (OclAttribute)new DefaultAttributeOclConverter().ToElements(context, "Test", "Value").Single();
-            result.Name.Should().Be("Test");
+            result.Name.Should().Be("test");
         }
     }
 }

--- a/source/Tests/Converters/OclDocumentOclConverterFixture.cs
+++ b/source/Tests/Converters/OclDocumentOclConverterFixture.cs
@@ -18,7 +18,7 @@ namespace Tests.Converters
                 .Be(
                     new OclBlock("Test")
                     {
-                        new OclAttribute("MyProp", "MyValue")
+                        new OclAttribute("my_prop", "MyValue")
                     }
                 );
         }

--- a/source/Tests/Namers/SnakeCaseOclNamerFixture.cs
+++ b/source/Tests/Namers/SnakeCaseOclNamerFixture.cs
@@ -1,0 +1,18 @@
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Ocl.Namers;
+
+namespace Tests.Namers
+{
+    public class SnakeCaseOclNamerFixture
+    {
+        [TestCase("SnakeCase", "snake_case")]
+        [TestCase("MultipleCAPitals", "multiple_capitals")]
+        [TestCase("", "")]
+        [TestCase("ALLUPPER", "allupper")]
+        [TestCase("alllower", "alllower")]
+        [TestCase("With A Space", "with_a_space")]
+        public void FormatName(string input, string expected)
+            => new SnakeCaseOclNamer().FormatName(input).Should().Be(expected);
+    }
+}

--- a/source/Tests/Namers/SnakeCaseOclNamerFixture.cs
+++ b/source/Tests/Namers/SnakeCaseOclNamerFixture.cs
@@ -1,5 +1,9 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
 using FluentAssertions;
 using NUnit.Framework;
+using Octopus.Ocl;
 using Octopus.Ocl.Namers;
 
 namespace Tests.Namers
@@ -14,5 +18,41 @@ namespace Tests.Namers
         [TestCase("With A Space", "with_a_space")]
         public void FormatName(string input, string expected)
             => new SnakeCaseOclNamer().FormatName(input).Should().Be(expected);
+
+        [Test]
+        public void GetPropertyNotFound()
+            => new SnakeCaseOclNamer()
+                .GetProperty("DoesNotExist", GetTestProperties())
+                .Should()
+                .BeNull();
+
+        [TestCase("MyProperty")]
+        [TestCase("myproperty")]
+        [TestCase("myproPERTy")]
+        [TestCase("My_Property")]
+        [TestCase("my_property")]
+        public void GetPropertySingleMatch(string name)
+            => new SnakeCaseOclNamer()
+                .GetProperty(name, GetTestProperties())
+                .Should()
+                .NotBeNull()
+                .And.Subject.Name.Should()
+                .Be("MyProperty");
+
+        [Test]
+        public void GetPropertyMultipleMatch()
+        {
+            Action action = () => new SnakeCaseOclNamer().GetProperty("DuplICAte", GetTestProperties());
+            action.Should().Throw<OclException>().WithMessage("Multiple properties match the name 'DuplICAte': duplicate, Duplicate");
+        }
+
+        IReadOnlyCollection<PropertyInfo> GetTestProperties()
+            => new
+                {
+                    MyProperty = "",
+                    duplicate = "",
+                    Duplicate = ""
+                }.GetType()
+                .GetProperties();
     }
 }

--- a/source/Tests/ToOclDoc/ToOclBodyDefaultBehaviourFixture.cs
+++ b/source/Tests/ToOclDoc/ToOclBodyDefaultBehaviourFixture.cs
@@ -21,7 +21,7 @@ namespace Tests.ToOclDoc
             OclConvert.ToOclDocument(new { MyProp = "MyValue" }, new OclSerializerOptions())
                 .Should()
                 .HaveChildrenExactly(
-                    new OclAttribute("MyProp", "MyValue")
+                    new OclAttribute("my_prop", "MyValue")
                 );
         }
 
@@ -39,11 +39,11 @@ namespace Tests.ToOclDoc
                 .HaveChildrenExactly(
                     new OclBlock("car")
                     {
-                        new OclAttribute("Doors", 2)
+                        new OclAttribute("doors", 2)
                     },
                     new OclBlock("car")
                     {
-                        new OclAttribute("Doors", 2)
+                        new OclAttribute("doors", 2)
                     }
                 );
         }

--- a/source/Tests/ToOclDoc/ToOclDocLabelFixture.cs
+++ b/source/Tests/ToOclDoc/ToOclDocLabelFixture.cs
@@ -14,7 +14,7 @@ namespace Tests.ToOclDoc
             OclConvert.ToOclDocument(new SampleWithLabelAttribute(), new OclSerializerOptions())
                 .Should()
                 .HaveChildrenExactly(
-                    new OclAttribute("ALabel", "The Label")
+                    new OclAttribute("my_label", "The Label")
                 );
         }
 
@@ -25,7 +25,7 @@ namespace Tests.ToOclDoc
             OclConvert.ToOclDocument(obj, new OclSerializerOptions())
                 .Should()
                 .HaveChildrenExactly(
-                    new OclBlock("Sample", "The Label")
+                    new OclBlock("sample", "The Label")
                 );
         }
 
@@ -45,14 +45,14 @@ namespace Tests.ToOclDoc
             OclConvert.ToOclDocument(obj, options)
                 .Should()
                 .HaveChildrenExactly(
-                    new OclBlock("Sample", "the name")
+                    new OclBlock("sample", "the name")
                 );
         }
 
         class SampleWithLabelAttribute
         {
             [OclLabel]
-            public string ALabel { get; } = "The Label";
+            public string MyLabel { get; } = "The Label";
         }
 
         class SampleWithANameProperty

--- a/source/Tests/ToOclDoc/ToOclDocNamingFixture.cs
+++ b/source/Tests/ToOclDoc/ToOclDocNamingFixture.cs
@@ -17,7 +17,7 @@ namespace Tests.ToOclDoc
                 .Be(
                     new OclDocument
                     {
-                        new OclAttribute("Sample", "My Value")
+                        new OclAttribute("sample", "My Value")
                     }
                 );
         }
@@ -31,7 +31,7 @@ namespace Tests.ToOclDoc
                 .Be(
                     new OclDocument
                     {
-                        new OclAttribute("Custom Name", "The Label")
+                        new OclAttribute("custom_name", "The Label")
                     }
                 );
         }
@@ -54,7 +54,7 @@ namespace Tests.ToOclDoc
                 .Be(
                     new OclDocument
                     {
-                        new OclBlock("The Name")
+                        new OclBlock("the_name")
                     }
                 );
         }
@@ -75,8 +75,8 @@ namespace Tests.ToOclDoc
             public override bool CanConvert(Type type)
                 => type == typeof(SampleWithANameProperty);
 
-            protected override string GetName(string name, object obj)
-                => ((dynamic)obj).Name;
+            protected override string GetName(OclConversionContext context, string name, object obj)
+                => context.Namer.FormatName(((dynamic)obj).Name);
 
             protected override IEnumerable<IOclElement> GetElements(object obj, OclConversionContext context)
                 => new IOclElement[0];


### PR DESCRIPTION
The `INamer` interface give the user the ability to customise the name of blocks and attributes without having to write a converter. The default implementation is `snake_case`. 

It also provides for the mapping of a name back to the properties.