### PR TITLE
Improve the error location reported by the Document parser.

### DIFF
--- a/source/Ocl/Parsing/OclParser.cs
+++ b/source/Ocl/Parsing/OclParser.cs
@@ -112,7 +112,7 @@ namespace Octopus.Ocl.Parsing
             select new OclBlock(name, labels.ToArray(), children.Single());
 
         static readonly Parser<OclDocument> Document =
-            from child in Block.Or<IOclElement>(Attribute).Token().Many().End()
+            from child in Block.Or<IOclElement>(Attribute).Token().XMany().End()
             select new OclDocument(child);
 
         public static Parser<T> SameLineToken<T>(this Parser<T> parser)

--- a/source/Tests/Parsing/ParserFixture.cs
+++ b/source/Tests/Parsing/ParserFixture.cs
@@ -29,7 +29,7 @@ namespace Tests.Parsing
                     Foo = ""Bar
             ");
 
-            error.Should().Be("Parsing failure: unexpected '\r'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar");
+            error.Should().Be("Parsing failure: unexpected '\n'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar");
         }
     }
 }

--- a/source/Tests/Parsing/ParserFixture.cs
+++ b/source/Tests/Parsing/ParserFixture.cs
@@ -29,8 +29,7 @@ namespace Tests.Parsing
                     Foo = ""Bar
             ");
 
-            var firstNewLineChar = Environment.NewLine[0];
-            error.Should().Be($"Parsing failure: unexpected '{firstNewLineChar}'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar");
+            error.Should().MatchRegex("Parsing failure: unexpected '\r|\n'; expected \" \\(Line 4, Column 31\\); recently consumed: Foo = \"Bar");
         }
     }
 }

--- a/source/Tests/Parsing/ParserFixture.cs
+++ b/source/Tests/Parsing/ParserFixture.cs
@@ -23,13 +23,16 @@ namespace Tests.Parsing
         [Test]
         public void InvalidDocumentReportsCorrectLineNumber()
         {
-            var (_, error) = OclParser.TryExecute(@"
+            var fooBarFooBar = @"
                     Foo = ""Bar""
 
                     Foo = ""Bar
-            ");
+            ".ToUnixLineEndings();
 
-            error.Should().MatchRegex("Parsing failure: unexpected '\r|\n'; expected \" \\(Line 4, Column 31\\); recently consumed: Foo = \"Bar");
+            var (_, error) = OclParser.TryExecute(fooBarFooBar);
+
+            var expected = "Parsing failure: unexpected '\n'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar";
+            error?.Should().Be(expected);
         }
     }
 }

--- a/source/Tests/Parsing/ParserFixture.cs
+++ b/source/Tests/Parsing/ParserFixture.cs
@@ -29,7 +29,7 @@ namespace Tests.Parsing
                     Foo = ""Bar
             ");
 
-            error.Should().Be("Parsing failure: unexpected 'F'; expected end of input (Line 4, Column 21); recently consumed:           ");
+            error.Should().Be("Parsing failure: unexpected '\r'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar");
         }
     }
 }

--- a/source/Tests/Parsing/ParserFixture.cs
+++ b/source/Tests/Parsing/ParserFixture.cs
@@ -29,7 +29,8 @@ namespace Tests.Parsing
                     Foo = ""Bar
             ");
 
-            error.Should().Be("Parsing failure: unexpected '\n'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar");
+            var firstNewLineChar = Environment.NewLine[0];
+            error.Should().Be($"Parsing failure: unexpected '{firstNewLineChar}'; expected \" (Line 4, Column 31); recently consumed: Foo = \"Bar");
         }
     }
 }


### PR DESCRIPTION
This PR replaces the backtracking `Many` combinator with a non-backtracking `XMany` combinator in the `Document` parser, which improves the error position in cases where top level elements fail with a partial parse.