### PR TITLE
Preserved newlines in the heredoc

### DIFF
--- a/source/Ocl/OclWriter.cs
+++ b/source/Ocl/OclWriter.cs
@@ -212,12 +212,17 @@ namespace Octopus.Ocl
                 writer.Write("-");
             writer.WriteLine(literal.HeredocTag);
 
-            foreach (var line in literal.Value.Split('\n'))
+            var lines = literal.Value.Split('\n');
+            for(var x = 0; x < lines.Length; x++)
             {
+                if(x > 0)
+                    writer.Write('\n');
+
                 if (isIndented)
                     WriteIndent(2);
-                writer.WriteLine(line.TrimEnd('\r'));
+                writer.Write(lines[x]);
             }
+            writer.WriteLine();
 
             if (isIndented)
                 WriteIndent(1);

--- a/source/Ocl/Parsing/HeredocParser.cs
+++ b/source/Ocl/Parsing/HeredocParser.cs
@@ -80,7 +80,7 @@ namespace Octopus.Ocl.Parsing
         static (string lineSeparator, IReadOnlyList<string> lines) TrimCarriageReturn(IEnumerable<string> lines)
         {
             var lineArr = lines.ToArray();
-            var hasCarriageReturn = lineArr.Any(l => l.EndsWith('\r'));
+            var hasCarriageReturn = lineArr.Take(lineArr.Length - 1).Any(l => l.EndsWith('\r'));
             var trimmed = lineArr.Select(l => l.TrimEnd('\r')).ToArray();
             var lineSeparator = hasCarriageReturn ? "\r\n" : "\n";
             return (lineSeparator, trimmed);

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.MostFieldsWithNonDefaults.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.MostFieldsWithNonDefaults.approved.txt
@@ -1,5 +1,9 @@
 default_guided_failure_mode = "On"
-description = "This is a description"
+description = <<-EOT
+        This is a 
+         multiline a description with trailing newline
+        
+    EOT
 environment_scope = "Specified"
 environments = ["Production", "Development"]
 multi_tenancy_mode = "TenantedOrUntenanted"

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixtureBase.cs
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixtureBase.cs
@@ -33,7 +33,7 @@ namespace Tests.RealLifeScenario
             => ExecuteTest(
                 new VcsRunbook("My Runbook")
                 {
-                    Description = "This is a description",
+                    Description = "This is a \n multiline a description with trailing newline\n",
                     EnvironmentScope = RunbookEnvironmentScope.Specified,
                     Environments = { "Production", "Development" },
                     ConnectivityPolicy = new ProjectConnectivityPolicy()
@@ -124,7 +124,6 @@ namespace Tests.RealLifeScenario
             );
 
         [Test]
-        [Ignore("Line endings are not handled correctly yet")]
         public void ScriptAction()
             => ExecuteTest(
                 new DeploymentAction("Backup the Database", ActionNames.Script)


### PR DESCRIPTION
Previously the code that attempted to preserve the new lines format of the source Heredoc included the final newline, which is put in by the writer and is therefor the system's newline format.

This fixes that and also makes sure we preserve leading and trailing newlines.