### PR TITLE
Upgrade to nuke 5.1.0

### DIFF
--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-source/Octopus.Ocl.sln

--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,0 +1,110 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Build Schema",
+  "$ref": "#/definitions/build",
+  "definitions": {
+    "build": {
+      "type": "object",
+      "properties": {
+        "Configuration": {
+          "type": "string",
+          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+          "enum": [
+            "Debug",
+            "Release"
+          ]
+        },
+        "Continue": {
+          "type": "boolean",
+          "description": "Indicates to continue a previously failed build attempt"
+        },
+        "Help": {
+          "type": "boolean",
+          "description": "Shows the help text for this build assembly"
+        },
+        "Host": {
+          "type": "string",
+          "description": "Host for execution. Default is 'automatic'",
+          "enum": [
+            "AppVeyor",
+            "AzurePipelines",
+            "Bamboo",
+            "Bitrise",
+            "GitHubActions",
+            "GitLab",
+            "Jenkins",
+            "SpaceAutomation",
+            "TeamCity",
+            "Terminal",
+            "TravisCI"
+          ]
+        },
+        "NoLogo": {
+          "type": "boolean",
+          "description": "Disables displaying the NUKE logo"
+        },
+        "Plan": {
+          "type": "boolean",
+          "description": "Shows the execution plan (HTML)"
+        },
+        "Profile": {
+          "type": "array",
+          "description": "Defines the profiles to load",
+          "items": {
+            "type": "string"
+          }
+        },
+        "Root": {
+          "type": "string",
+          "description": "Root directory during build execution"
+        },
+        "Skip": {
+          "type": "array",
+          "description": "List of targets to be skipped. Empty list skips all dependencies",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CalculateVersion",
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "Pack",
+              "Restore",
+              "Test"
+            ]
+          }
+        },
+        "Solution": {
+          "type": "string",
+          "description": "Path to a solution file that is automatically loaded"
+        },
+        "Target": {
+          "type": "array",
+          "description": "List of targets to be invoked. Default is '{default_target}'",
+          "items": {
+            "type": "string",
+            "enum": [
+              "CalculateVersion",
+              "Clean",
+              "Compile",
+              "CopyToLocalPackages",
+              "Pack",
+              "Restore",
+              "Test"
+            ]
+          }
+        },
+        "Verbosity": {
+          "type": "string",
+          "description": "Logging verbosity during build execution. Default is 'Normal'",
+          "enum": [
+            "Minimal",
+            "Normal",
+            "Quiet",
+            "Verbose"
+          ]
+        }
+      }
+    }
+  }
+}

--- a/.nuke/parameters.json
+++ b/.nuke/parameters.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "./build.schema.json",
+  "Solution": "source/Octopus.Ocl.sln"
+}

--- a/NuGet.Config
+++ b/NuGet.Config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <packageSources>
+    <add key="NuGet.org v3" value="https://api.nuget.org/v3/index.json" />
+    <add key="feedz.io" value="https://f.feedz.io/octopus-deploy/dependencies/nuget" />
+  </packageSources>
+</configuration>

--- a/build.cmd
+++ b/build.cmd
@@ -1,6 +1,7 @@
 :; set -eo pipefail
-:; ./build.sh "$@"
+:; SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
+:; ${SCRIPT_DIR}/build.sh "$@"
 :; exit $?
 
 @ECHO OFF
-powershell -ExecutionPolicy ByPass -NoProfile %0\..\build.ps1 %*
+powershell -ExecutionPolicy ByPass -NoProfile "%~dp0build.ps1" %*

--- a/build.ps1
+++ b/build.ps1
@@ -14,10 +14,10 @@ $PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent
 ###########################################################################
 
 $BuildProjectFile = "$PSScriptRoot\build\_build.csproj"
-$TempDirectory = "$PSScriptRoot\\.tmp"
+$TempDirectory = "$PSScriptRoot\\.nuke\temp"
 
 $DotNetGlobalFile = "$PSScriptRoot\\global.json"
-$DotNetInstallUrl = "https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.ps1"
+$DotNetInstallUrl = "https://dot.net/v1/dotnet-install.ps1"
 $DotNetChannel = "Current"
 
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 1

--- a/build.sh
+++ b/build.sh
@@ -10,10 +10,10 @@ SCRIPT_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd)
 ###########################################################################
 
 BUILD_PROJECT_FILE="$SCRIPT_DIR/build/_build.csproj"
-TEMP_DIRECTORY="$SCRIPT_DIR//.tmp"
+TEMP_DIRECTORY="$SCRIPT_DIR//.nuke/temp"
 
 DOTNET_GLOBAL_FILE="$SCRIPT_DIR//global.json"
-DOTNET_INSTALL_URL="https://raw.githubusercontent.com/dotnet/cli/master/scripts/obtain/dotnet-install.sh"
+DOTNET_INSTALL_URL="https://dot.net/v1/dotnet-install.sh"
 DOTNET_CHANNEL="Current"
 
 export DOTNET_CLI_TELEMETRY_OPTOUT=1

--- a/build/Configuration.cs
+++ b/build/Configuration.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel;
+using System.Linq;
+using Nuke.Common.Tooling;
+
+[TypeConverter(typeof(TypeConverter<Configuration>))]
+public class Configuration : Enumeration
+{
+    public static Configuration Debug = new Configuration { Value = nameof(Debug) };
+    public static Configuration Release = new Configuration { Value = nameof(Release) };
+
+    public static implicit operator string(Configuration configuration)
+    {
+        return configuration.Value;
+    }
+}

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,15 +2,24 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.0</TargetFramework>
+    <TargetFramework>net5.0</TargetFramework>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="0.24.11" />
-    <PackageDownload Include="GitVersion.Tool" Version="[5.1.1]" />
+    <PackageReference Include="Nuke.Common" Version="5.1.0" />
+    <PackageReference Include="Nuke.OctoVersion" Version="0.2.453" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\.gitignore">
+      <Link>config\.gitignore</Link>
+    </Content>
+    <Content Include="..\octoversion.json">
+      <Link>config\octoversion.json</Link>
+    </Content>
   </ItemGroup>
 
 </Project>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "5.0.104",
+    "rollForward": "latestFeature"
+  }
+}

--- a/octoversion.json
+++ b/octoversion.json
@@ -1,0 +1,3 @@
+{
+  "NonPreReleaseTags": ["refs/heads/main"]
+}

--- a/source/Octopus.Ocl.sln
+++ b/source/Octopus.Ocl.sln
@@ -8,10 +8,6 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "_", "_", "{900879BA-C300-47
 ProjectSection(SolutionItems) = preProject
 	..\.gitattributes = ..\.gitattributes
 	..\.gitignore = ..\.gitignore
-	..\build.cmd = ..\build.cmd
-	..\build.ps1 = ..\build.ps1
-	..\build.sh = ..\build.sh
-	..\GitVersion.yml = ..\GitVersion.yml
 	..\LICENSE.txt = ..\LICENSE.txt
 	..\README.md = ..\README.md
 EndProjectSection
@@ -25,10 +21,9 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "build", "build", "{8E82EBC5-EBAB-4D54-953E-12C217C3099D}"
 ProjectSection(SolutionItems) = preProject
 	..\build\.editorconfig = ..\build\.editorconfig
-	..\build\_build.csproj = ..\build\_build.csproj
-	..\build\_build.csproj.DotSettings = ..\build\_build.csproj.DotSettings
-	..\build\Build.cs = ..\build\Build.cs
 EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "_build", "..\build\_build.csproj", "{A5D7D80B-35A2-4D84-9081-89BAF06A6015}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -44,5 +39,7 @@ Global
 		{43A59954-CE41-4554-92C0-750E9F29994E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{43A59954-CE41-4554-92C0-750E9F29994E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{43A59954-CE41-4554-92C0-750E9F29994E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A5D7D80B-35A2-4D84-9081-89BAF06A6015}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A5D7D80B-35A2-4D84-9081-89BAF06A6015}.Release|Any CPU.ActiveCfg = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -13,7 +13,6 @@
 
     <PackageReference Include="Octopus.Data" Version="5.3.0" />
     <PackageReference Include="Octopus.Server.Extensibility" Version="12.1.0" />
-    <PackageReference Include="Octopus.TinyTypes" Version="0.1.313" />
     <PackageReference Include="Assent" Version="1.7.0" />
     <PackageReference Include="FluentAssertions" Version="5.10.3" />
     <PackageReference Include="FluentAssertions.Extensions" Version="1.0.18" />


### PR DESCRIPTION
We [upgraded](https://github.com/OctopusDeploy/tool-containers/pull/25) the base build image to install the latest nuke.globaltool (version 5.1.0).
Nuke 5.1.0 [includes a new version](https://github.com/nuke-build/nuke/commit/bef28aab33d202688f67f527f7692b360ba93fa4) of GitVersion.Tool.
This meant we [had to update](https://github.com/OctopusDeploy/tool-containers/pull/25/files#diff-3dc3767944d5097e69dbc20d45548730bb43dfdbde1be7edfdb4140a66c6cfa1R58) the path (`LD_LIBRARY_PATH`) to the new native tool binaries.
Unfortunately this meant that while new stuff will build, old stuff will not.

As a quick fix, we are updating all projects to nuke 5.1.0 while we ponder the proper fix.