### PR TITLE
Drop Nuke.OctoVersion and use the one built into nuke itself

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -33,15 +33,22 @@
             "GitHubActions",
             "GitLab",
             "Jenkins",
+            "Rider",
             "SpaceAutomation",
             "TeamCity",
             "Terminal",
-            "TravisCI"
+            "TravisCI",
+            "VisualStudio",
+            "VSCode"
           ]
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
+        },
+        "Partition": {
+          "type": "string",
+          "description": "Partition to use on CI"
         },
         "Plan": {
           "type": "boolean",

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,12 +1,12 @@
+// ReSharper disable RedundantUsingDirective
 using System;
 using Nuke.Common;
 using Nuke.Common.Execution;
 using Nuke.Common.IO;
 using Nuke.Common.ProjectModel;
 using Nuke.Common.Tools.DotNet;
+using Nuke.Common.Tools.OctoVersion;
 using Nuke.Common.Utilities.Collections;
-using Nuke.OctoVersion;
-using OctoVersion.Core;
 using static Nuke.Common.IO.FileSystemTasks;
 using static Nuke.Common.Tools.DotNet.DotNetTasks;
 
@@ -28,7 +28,7 @@ class Build : NukeBuild
     [Solution]
     readonly Solution Solution;
 
-    [NukeOctoVersion] readonly OctoVersionInfo OctoVersionInfo;
+    [OctoVersion] readonly OctoVersionInfo OctoVersionInfo;
 
     AbsolutePath SourceDirectory => RootDirectory / "source";
     AbsolutePath ArtifactsDirectory => RootDirectory / "artifacts";

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -6,11 +6,15 @@
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>
+    <NukeTelemetryVersion>1</NukeTelemetryVersion>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="5.3.0" />
-    <PackageReference Include="Nuke.OctoVersion" Version="0.2.453" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageDownload Include="OctoVersion.Tool" Version="[0.2.560]" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Drop out the `Nuke.OctoVersion` dependency and use [the one](https://github.com/nuke-build/nuke/pull/766) that's now built into nuke itself