### PR TITLE
Map attributes no longer followed by extra newline

### DIFF
--- a/source/Ocl/OclWriter.cs
+++ b/source/Ocl/OclWriter.cs
@@ -273,7 +273,7 @@ namespace Octopus.Ocl
             }
 
             WriteIndent();
-            writer.WriteLine("}");
+            writer.Write("}");
         }
 
         void WriteSingleLineStringLiteral(string s)

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.IisAction.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.IisAction.approved.txt
@@ -33,6 +33,5 @@ steps "Deploy Website" {
             Octopus.Action.Package.JsonConfigurationVariablesTargets = "appsettings.json"
             Octopus.Action.Package.PackageId = "OctoFX.Web"
         }
-
     }
 }

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.MostFieldsWithNonDefaults.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.MostFieldsWithNonDefaults.approved.txt
@@ -25,7 +25,6 @@ steps "Script Step" {
         Octopus.Action.TargetRoles = "Portal"
         StepProperty = "Value1"
     }
-
     start_trigger = "StartWithPrevious"
 
     actions "Script Step" {
@@ -39,7 +38,6 @@ steps "Script Step" {
         properties = {
             Action.Prop = "The Value"
         }
-
         tenant_tags = ["David/Who"]
         worker_pool_id_or_name = "My Worker Pool"
         worker_pool_variable = "WorkerPoolVar"

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.ScriptAction.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.ScriptAction.approved.txt
@@ -50,6 +50,5 @@ steps "Backup the Database" {
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
         }
-
     }
 }

--- a/source/Tests/ToString/OclWriterFixture.cs
+++ b/source/Tests/ToString/OclWriterFixture.cs
@@ -292,6 +292,66 @@ ZZZ
                 .Be(expected.ToUnixLineEndings());
         }
 
+        [Test]
+        public void CollectionAttributeFollowedByEndOfBlock()
+        {
+
+            var block = new OclBlock("OuterBlock")
+            {
+                new OclBlock("InnerBlock")
+                {
+                    new OclAttribute("MapAttribute",
+                        new Dictionary<string, object>
+                            { { "alpha", 1 }, {"bravo", 2} })
+                }
+            };
+            
+            const string expected = @"OuterBlock {
+
+    InnerBlock {
+        MapAttribute = {
+            alpha = 1
+            bravo = 2
+        }
+    }
+}";
+            
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected.ToUnixLineEndings());
+        }
+        
+        [Test]
+        public void CollectionAttributeFollowedByAttribute()
+        {
+
+            var block = new OclBlock("OuterBlock")
+            {
+                new OclBlock("InnerBlock")
+                {
+                    new OclAttribute("MapAttribute",
+                        new Dictionary<string, object>
+                            { { "alpha", 1 }, {"bravo", 2} }),
+                    new OclAttribute("StringAttribute", "Value")
+                }
+            };
+            
+            const string expected = @"OuterBlock {
+
+    InnerBlock {
+        MapAttribute = {
+            alpha = 1
+            bravo = 2
+        }
+        StringAttribute = ""Value""
+    }
+}";
+            
+            Execute(w => w.Write(block))
+                .Should()
+                .Be(expected.ToUnixLineEndings());
+        }
+
         string Execute(Action<OclWriter> when, OclSerializerOptions? options = null)
         {
             var sb = new StringBuilder();


### PR DESCRIPTION
Attributes with map (dictionary) values were always being followed by an extra newline.  This made the OCL a bit messy. 

This was very obvious when followed by the end of a block, e.g.
**Before**:

```
step "Confirm changes on Staging slot" {
    start_trigger = "StartWithPrevious"

    action "Confirm changes on Staging slot" {
        action_type = "Octopus.Manual"
        properties = {
            Octopus.Action.Manual.BlockConcurrentDeployments = "False"
        }

    }
}
```

**After**:

```
step "Confirm changes on Staging slot" {
    start_trigger = "StartWithPrevious"

    action "Confirm changes on Staging slot" {
        action_type = "Octopus.Manual"
        properties = {
            Octopus.Action.Manual.BlockConcurrentDeployments = "False"
        }
    }
}
```

But this change will also take effect when followed by another attribute.  e.g. (note the `worker_pool_variable`)

Before:
```
action "Deploy Octopus.Library (new App Service Step)" {
        action_type = "Octopus.AzureAppService"
        properties = {
            Octopus.Action.Azure.DeploymentSlot = "#{AzureSlotName}"
            Octopus.Action.Azure.DeploymentType = "Package"
        }

        worker_pool_variable = "ubuntu"

        packages {
            acquisition_location = "Server"
            feed = "Octopus Server (built-in)"
            package_id = "Octopus.Library"
        }
    }
```

After:
```
action "Deploy Octopus.Library (new App Service Step)" {
        action_type = "Octopus.AzureAppService"
        is_disabled = true
        properties = {
            Octopus.Action.Azure.DeploymentSlot = "#{AzureSlotName}"
            Octopus.Action.Azure.DeploymentType = "Package"
        }
        worker_pool_variable = "ubuntu"

        packages {
            acquisition_location = "Server"
            feed = "Octopus Server (built-in)"
            package_id = "Octopus.Library"
        }
    }
```