### PR TITLE
Override OclDocument ToString to simplify getting the string representation

### DIFF
--- a/source/Ocl/OclDocument.cs
+++ b/source/Ocl/OclDocument.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Text;
 
 namespace Octopus.Ocl
 {
@@ -15,5 +18,14 @@ namespace Octopus.Ocl
         }
 
         public string Name => "";
+
+        public override string ToString()
+        {
+            var sb = new StringBuilder();
+            using var tw = new StringWriter(sb, CultureInfo.InvariantCulture);
+            using var writer = new OclWriter(tw);
+            writer.Write(this);
+            return sb.ToString();
+        }
     }
 }


### PR DESCRIPTION
This roughly mimics what is possible in the the [JToken class](https://github.com/JamesNK/Newtonsoft.Json/blob/c9e12bc4755c786a9073dddf1be14cd27823a498/Src/Newtonsoft.Json/Linq/JToken.cs#L431) and makes it a little easier when debugging, or just trying to get a simple string representation for testing.
