### PR TITLE
Reduce newlines when serialising OCL

### DIFF
--- a/source/Ocl/OclWriter.cs
+++ b/source/Ocl/OclWriter.cs
@@ -15,6 +15,7 @@ namespace Octopus.Ocl
         readonly TextWriter writer;
         int currentIndent;
         bool isFirstLine = true;
+        bool isFirstChildInBlock;
         bool lastWrittenWasBlock;
 
         public OclWriter(StringBuilder sb, OclSerializerOptions? options = null)
@@ -60,7 +61,7 @@ namespace Octopus.Ocl
 
         public void Write(OclBlock block)
         {
-            if (!isFirstLine && !lastWrittenWasBlock)
+            if (!isFirstLine && !lastWrittenWasBlock && !isFirstChildInBlock)
                 writer.WriteLine();
             WriteNextLine();
             WriteIndent();
@@ -74,14 +75,23 @@ namespace Octopus.Ocl
 
             writer.Write(" {");
 
-            currentIndent++;
-            foreach (var child in block)
-                Write(child);
-            currentIndent--;
+            if (block.Any())
+            {
+                currentIndent++;
+                isFirstChildInBlock = true;
 
-            writer.WriteLine();
+                foreach (var child in block)
+                {
+                    Write(child);
+                    isFirstChildInBlock = false;
+                }
 
-            WriteIndent();
+                currentIndent--;
+
+                writer.WriteLine();
+                WriteIndent();
+            }
+
             writer.Write("}");
 
             lastWrittenWasBlock = true;

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.IisAction.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.IisAction.approved.txt
@@ -8,7 +8,6 @@ connectivity_policy {
 project_id = "Projects-1"
 
 steps "Deploy Website" {
-
     actions "Deploy Website" {
         action_type = "Octopus.IIS"
         properties = {

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.Rolling.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.Rolling.approved.txt
@@ -8,7 +8,6 @@ connectivity_policy {
 project_id = "Projects-1"
 
 steps "My Rolling Step" {
-
     actions "First" {
         action_type = "Octopus.Script"
     }

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.ScriptAction.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.ScriptAction.approved.txt
@@ -8,7 +8,6 @@ connectivity_policy {
 project_id = "Projects-1"
 
 steps "Backup the Database" {
-
     actions "Backup the Database" {
         action_type = "Octopus.Script"
         properties = {

--- a/source/Tests/ToString/OclWriterFixture.cs
+++ b/source/Tests/ToString/OclWriterFixture.cs
@@ -156,13 +156,13 @@ ZZZ
         public void WriteBlockEmpty()
             => Execute(w => w.Write(new OclBlock("MyBlock")))
                 .Should()
-                .Be("MyBlock {\n}");
+                .Be("MyBlock {}");
 
         [Test]
         public void WriteBlockSpecialCharactersInName()
             => Execute(w => w.Write(new OclBlock("My0%&2_'\"-Block")))
                 .Should()
-                .Be("My0__2___-Block {\n}");
+                .Be("My0__2___-Block {}");
 
         [Test]
         public void WriteBlockSingleLabel()
@@ -172,7 +172,7 @@ ZZZ
 
             Execute(w => w.Write(block))
                 .Should()
-                .Be("MyBlock \"MyLabel\" {\n}");
+                .Be("MyBlock \"MyLabel\" {}");
         }
 
         [Test]
@@ -185,7 +185,7 @@ ZZZ
 
             Execute(w => w.Write(block))
                 .Should()
-                .Be("MyBlock \"MyLabel\" \"OtherLabel\" \"LastLabel\" {\n}");
+                .Be("MyBlock \"MyLabel\" \"OtherLabel\" \"LastLabel\" {}");
         }
 
         [Test]
@@ -196,7 +196,7 @@ ZZZ
 
             Execute(w => w.Write(block))
                 .Should()
-                .Be("MyBlock \"My\\\"Label\" {\n}");
+                .Be("MyBlock \"My\\\"Label\" {}");
         }
 
         [Test]
@@ -208,9 +208,7 @@ ZZZ
             };
 
             var expected = @"MyBlock {
-
-    Child {
-    }
+    Child {}
 }";
 
             Execute(w => w.Write(block))
@@ -281,8 +279,7 @@ ZZZ
         ThirdChild = 3
     }
 
-    Fourth {
-    }
+    Fourth {}
 
     Last = 9
 }";
@@ -306,7 +303,6 @@ ZZZ
             };
 
             const string expected = @"OuterBlock {
-
     InnerBlock {
         MapAttribute = {
             alpha = 1
@@ -335,7 +331,6 @@ ZZZ
             };
 
             const string expected = @"OuterBlock {
-
     InnerBlock {
         MapAttribute = {
             alpha = 1


### PR DESCRIPTION
There are two main changes to serialisation in this PR:

1. Do not write a newline before a block if it is the first child in a block
2. Write empty blocks as a single line

## First child blocks
We write a newline before every block, even if it is the first child in a block. This change removes that new line if it's the first child in a block. A newline is written before every additional block.

### Before
```hcl
Parent {

    ChildOne {
    }
}
```

### After
```hcl
Parent {
    ChildOne {
    }
}
```

## Empty blocks
Empty blocks currently serialise over two lines. This change writes empty block as a single line.

### Before
```hcl
Parent {
    
    ChildOne {
    }
}
```

### After
```hcl
Parent {

    ChildOne {}
}
```

## All together now!
```hcl
Parent {
    ChildOne {}
}
```