### PR TITLE
Update HereDoc to consider end tag in unindent calculation

### DIFF
--- a/source/Ocl/OclSerializerOptions.cs
+++ b/source/Ocl/OclSerializerOptions.cs
@@ -9,7 +9,13 @@ namespace Octopus.Ocl
     /// </summary>
     public class OclSerializerOptions
     {
-        public char IndentChar { get; set; } = ' ';
+        /// <summary>
+        /// What character is used when indenting the OCL text.
+        /// This is not settable as it is
+        /// currently not used in some places in the static Parser 
+        /// </summary>
+        public char IndentChar { get; internal set; } = ' ';
+
         public int IndentDepth { get; set; } = 4;
         public string DefaultHeredocTag { get; set; } = "EOT";
         public List<IOclConverter> Converters { get; set; } = new List<IOclConverter>();

--- a/source/Ocl/OclWriter.cs
+++ b/source/Ocl/OclWriter.cs
@@ -252,7 +252,7 @@ namespace Octopus.Ocl
             writer.WriteLine();
 
             if (isIndented)
-                WriteIndent(1);
+                WriteIndent(2);
             writer.Write(literal.HeredocTag);
         }
 

--- a/source/Ocl/OclWriter.cs
+++ b/source/Ocl/OclWriter.cs
@@ -232,7 +232,8 @@ namespace Octopus.Ocl
             }
 
             var isIndented = literal.Format == OclStringLiteralFormat.IndentedHeredoc;
-
+            var indentSize = 2;
+            
             writer.Write("<<");
             if (isIndented)
                 writer.Write("-");
@@ -245,14 +246,15 @@ namespace Octopus.Ocl
                     writer.Write('\n');
 
                 if (isIndented)
-                    WriteIndent(2);
+                    WriteIndent(indentSize);
                 writer.Write(lines[x]);
             }
-
             writer.WriteLine();
 
+            // Ident the ending tag by the same amount as the text value above.
+            // This ensures that when being read back out the parsed text line indentation can be made relative to this ending tag.
             if (isIndented)
-                WriteIndent(2);
+                WriteIndent(indentSize);
             writer.Write(literal.HeredocTag);
         }
 

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.MostFieldsWithNonDefaults.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.MostFieldsWithNonDefaults.approved.txt
@@ -3,7 +3,7 @@ description = <<-EOT
         This is a 
          multiline a description with trailing newline
         
-    EOT
+        EOT
 environment_scope = "Specified"
 environments = ["Production", "Development"]
 multi_tenancy_mode = "TenantedOrUntenanted"

--- a/source/Tests/RealLifeScenario/RealLifeScenarioFixture.ScriptAction.approved.txt
+++ b/source/Tests/RealLifeScenario/RealLifeScenarioFixture.ScriptAction.approved.txt
@@ -45,7 +45,7 @@ steps "Backup the Database" {
                 
                 write-output $entryResult | ft
                 
-            EOT
+                EOT
             Octopus.Action.Script.ScriptSource = "Inline"
             Octopus.Action.Script.Syntax = "PowerShell"
         }

--- a/source/Tests/ToString/OclWriterFixture.cs
+++ b/source/Tests/ToString/OclWriterFixture.cs
@@ -154,9 +154,21 @@ ZZZ
         }
         
         [Test]
-        [TestCase("Hello\r\nWorld", "blah = <<-EOT\r\n        Hello\r\n        World\r\n        EOT",  Description = "No Indentation")]
-        [TestCase("\tHello\r\n\tWorld", "blah = <<-EOT\r\n        \tHello\r\n        \tWorld\r\n        EOT",  Description = "Double Indent Preserved")]
-        [TestCase("Hello\r\n\t\tWorld", "blah = <<-EOT\r\n        Hello\r\n        \t\tWorld\r\n        EOT",  Description = "Single Property Indented")]
+        [TestCase(@"Hello
+World", @"blah = <<-EOT
+        Hello
+        World
+        EOT",  Description = "No Indentation")]
+        [TestCase(@"    Hello
+    World", @"blah = <<-EOT
+            Hello
+            World
+        EOT",  Description = "Double Indent Preserved")]
+        [TestCase(@"Hello
+        World", @"blah = <<-EOT
+        Hello
+                World
+        EOT",  Description = "Single Property Indented")]
         public void MultilineStringsSupportHeredocLineFormat(string propertyText, string expectedOcl)
         {
             var serializer = new OclSerializer(new OclSerializerOptions());

--- a/source/Tests/ToString/OclWriterFixture.cs
+++ b/source/Tests/ToString/OclWriterFixture.cs
@@ -173,6 +173,36 @@ ZZZ
             deserializedFoo.Blah.Should().Be(originalFoo.Blah);
         }
         
+        
+             
+        [Test]
+        [TestCase(@"blah = <<-EOT
+        	Hello
+        	World
+        EOT")]
+        public void MultilineStringsSupportHeredocLineFormat1(string expectedRaw)
+        {
+            var options = new OclSerializerOptions();
+            var serializer = new OclSerializer(options);
+            
+            
+            var dualIndent = new Foo() { Blah = "\tHello\r\n\tWorld" };
+            var dualIndentRaw = serializer.Serialize(dualIndent);
+            
+            var singleIndent = new Foo() { Blah = "Hello\r\n\tWorld" };
+            var singleIndentRaw = serializer.Serialize(singleIndent);
+
+            singleIndentRaw = @"blah = <<-EOT
+        	Hello
+        	World
+    EOT";
+            
+            var singleIndentDeserialized = serializer.Deserialize<Foo>(singleIndentRaw);
+            var dualIndentDeserialized = serializer.Deserialize<Foo>(dualIndentRaw);
+
+        }
+        
+        
         public class Foo
         {
             public string? Blah { get; set; }


### PR DESCRIPTION
## Summary
Relating to [internal ticket 30965](https://app.shortcut.com/octopusdeploy/story/30965/whitespace-trimmed-from-multi-line-variables-once-committed) there have been some problems storing indented scripts in heredocs. This fix changes the Ocl Parser to factor in the ending tag to more accurately calculate the de-indenting.

Fixes https://github.com/OctopusDeploy/Issues/issues/7786

## Background
The current parser logic takes the minimum indent count from the text block and de-indents based on that. This means that the block cannot be entirely indented.

## Resolution
Based on the [Hcl Docs](https://developer.hashicorp.com/terraform/language/expressions/strings#indented-heredocs) 
>  Terraform analyses the lines in the sequence to find the one with the smallest number of leading spaces, and then trims that many spaces from the beginning of all of the lines...

The [Hcl Specs](https://github.com/hashicorp/hcl/blob/main/hclsyntax/spec.md#template-expressions) don't make it much clearer
> If a heredoc template is introduced with the <<- symbol, any literal string at the start of each line is analyzed to find the minimum number of leading spaces, and then that number of prefix spaces is removed from all line-leading literal strings. The final closing marker may also have an arbitrary number of spaces preceding it on its line.

While it is unclear from this if it includes the ending tag, given the spec indicates that the format is defined by
```hcl
TemplateExpr = quotedTemplate | heredocTemplate;
quotedTemplate = (as defined in prose above);
heredocTemplate = (
    ("<<" | "<<-") Identifier Newline
    (content as defined in prose above)
    Identifier Newline
);
```
including the ending heredoc tag as part of the indent calculation, we can use _it_ to provide the baseline number of relative indents for the rest of the text block.

### Examples
![image](https://user-images.githubusercontent.com/1830666/201515753-50924397-f180-4e82-93ba-058b8021610d.png)

![image](https://user-images.githubusercontent.com/1830666/201515772-59c0d2cd-9d3f-43c8-8b79-93e911a941a5.png)

![image](https://user-images.githubusercontent.com/1830666/201515799-96b3d6c8-29e6-4fb6-9dcc-4e85b3dd7f73.png)



