### PR TITLE
Added OclEnumDefaultValueAttribute

### DIFF
--- a/source/Ocl/Converters/EnumAttributeOclConverter.cs
+++ b/source/Ocl/Converters/EnumAttributeOclConverter.cs
@@ -33,7 +33,22 @@ namespace Octopus.Ocl.Converters
 
         public IEnumerable<IOclElement> ToElements(OclConversionContext context, PropertyInfo? propertyInfo, object obj)
         {
-            var isDefault = Activator.CreateInstance(obj.GetType()).Equals(obj);
+            var isDefault = false;
+            var defaultValueAttributeType = typeof(OclDefaultEnumValueAttribute);
+            var defaultValueAttribute = propertyInfo?.GetCustomAttribute(defaultValueAttributeType);
+
+            if (defaultValueAttribute != null)
+            {
+                var defaultValueProperty = defaultValueAttributeType.GetProperty("DefaultValue");
+                var defaultValue = defaultValueProperty?.GetValue(defaultValueAttribute);
+
+                isDefault = Equals(obj, defaultValue);
+            }
+            else
+            {
+                isDefault = Activator.CreateInstance(obj.GetType()).Equals(obj);
+            }
+
             if (!isDefault)
                 yield return new OclAttribute(context.Namer.GetName(propertyInfo!), obj.ToString());
         }

--- a/source/Ocl/Converters/OclEnumDefaultValueAttribute.cs
+++ b/source/Ocl/Converters/OclEnumDefaultValueAttribute.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Octopus.Ocl.Converters
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public class OclDefaultEnumValueAttribute : Attribute
+    {
+        public OclDefaultEnumValueAttribute(object defaultValue)
+        {
+            if (!(defaultValue is Enum))
+            {
+                throw new ArgumentException("defaultValue must be an enum", nameof(defaultValue));
+            }
+
+            DefaultValue = defaultValue;
+        }
+
+        public object DefaultValue { get; }
+    }
+}

--- a/source/Tests/Converters/EnumAttributeConverterFixture.cs
+++ b/source/Tests/Converters/EnumAttributeConverterFixture.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using System.Linq;
+using FluentAssertions;
+using NUnit.Framework;
+using Octopus.Ocl;
+using Octopus.Ocl.Converters;
+
+namespace Tests.Converters
+{
+    internal class EnumAttributeConverterFixture
+    {
+        [Test]
+        public void WhenConvertingEnum_ValueIsEnumDefault_ReturnsNull()
+        {
+            var context = new OclConversionContext(new OclSerializerOptions());
+
+            var result = (OclAttribute?)new EnumAttributeOclConverter().ToElements(context, typeof(Dummy).GetProperty(nameof(Dummy.TestProperty))!, Test.Value1).SingleOrDefault();
+
+            result.Should().BeNull();
+        }
+
+        [Test]
+        public void WhenConvertingEnum_ValueIsNotEnumDefault_ReturnsValueOfProperty()
+        {
+            var context = new OclConversionContext(new OclSerializerOptions());
+
+            var result = (OclAttribute?)new EnumAttributeOclConverter().ToElements(context, typeof(Dummy).GetProperty(nameof(Dummy.TestProperty))!, Test.Value2).SingleOrDefault();
+
+            result.Should().NotBeNull();
+            result!.Value.Should().Be("Value2");
+        }
+
+        [Test]
+        public void WhenConvertingEnumWithDefaultAttribute_ValueIsEnumDefault_ReturnsValueOfProperty()
+        {
+            var context = new OclConversionContext(new OclSerializerOptions());
+
+            var result = (OclAttribute?)new EnumAttributeOclConverter().ToElements(context, typeof(DummyWithDefault).GetProperty(nameof(DummyWithDefault.TestProperty))!, Test.Value1).SingleOrDefault();
+
+            result.Should().NotBeNull();
+            result!.Value.Should().Be("Value1");
+        }
+
+        [Test]
+        public void WhenConvertingEnumWithDefaultAttribute_ValueIsNotADefault_ReturnsValueOfProperty()
+        {
+            var context = new OclConversionContext(new OclSerializerOptions());
+
+            var result = (OclAttribute?)new EnumAttributeOclConverter().ToElements(context, typeof(DummyWithDefault).GetProperty(nameof(DummyWithDefault.TestProperty))!, Test.Value2).SingleOrDefault();
+
+            result.Should().NotBeNull();
+            result!.Value.Should().Be("Value2");
+        }
+
+        [Test]
+        public void WhenConvertingEnumWithDefaultAttribute_ValueIstAttributedDefault_ReturnsNull()
+        {
+            var context = new OclConversionContext(new OclSerializerOptions());
+
+            var result = (OclAttribute?)new EnumAttributeOclConverter().ToElements(context, typeof(DummyWithDefault).GetProperty(nameof(DummyWithDefault.TestProperty))!, Test.Value3).SingleOrDefault();
+
+            result.Should().BeNull();
+        }
+
+        enum Test
+        {
+            Value1,
+            Value2,
+            Value3,
+        }
+
+        class Dummy
+        {
+            public Test TestProperty { get; } = Test.Value1;
+        }
+
+        class DummyWithDefault
+        {
+            [OclDefaultEnumValue(Test.Value3)]
+            public Test TestProperty { get; } = Test.Value1;
+        }
+    }
+}


### PR DESCRIPTION
## Background
We have found a scenario where an enum has a default value, but the class that uses the enum has a different value than the default value of the property. In this case, the OCL Attribute will be produced when the property is unchanged. The OCL Attribute will be skipped when the value of the property matches the default value of the Enum(but not the default value of  the object being converted)

## Result
This PR adds a solution. By allowing a developer to specify a default value for an enum field via an attribute, the OCL converter can perform correctly when serializing these values.