### PR TITLE
Update to .NET 8

### DIFF
--- a/.nuke/build.schema.json
+++ b/.nuke/build.schema.json
@@ -1,23 +1,72 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
-  "title": "Build Schema",
-  "$ref": "#/definitions/build",
+  "properties": {
+    "AutoDetectBranch": {
+      "type": "boolean",
+      "description": "Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI"
+    },
+    "Configuration": {
+      "type": "string",
+      "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
+      "enum": [
+        "Debug",
+        "Release"
+      ]
+    },
+    "OCTOVERSION_CurrentBranch": {
+      "type": "string",
+      "description": "Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable OCTOVERSION_CurrentBranch"
+    },
+    "Solution": {
+      "type": "string",
+      "description": "Path to a solution file that is automatically loaded"
+    }
+  },
   "definitions": {
-    "build": {
-      "type": "object",
+    "Host": {
+      "type": "string",
+      "enum": [
+        "AppVeyor",
+        "AzurePipelines",
+        "Bamboo",
+        "Bitbucket",
+        "Bitrise",
+        "GitHubActions",
+        "GitLab",
+        "Jenkins",
+        "Rider",
+        "SpaceAutomation",
+        "TeamCity",
+        "Terminal",
+        "TravisCI",
+        "VisualStudio",
+        "VSCode"
+      ]
+    },
+    "ExecutableTarget": {
+      "type": "string",
+      "enum": [
+        "CalculateVersion",
+        "Clean",
+        "Compile",
+        "CopyToLocalPackages",
+        "Pack",
+        "Restore",
+        "Test"
+      ]
+    },
+    "Verbosity": {
+      "type": "string",
+      "description": "",
+      "enum": [
+        "Verbose",
+        "Normal",
+        "Minimal",
+        "Quiet"
+      ]
+    },
+    "NukeBuild": {
       "properties": {
-        "AutoDetectBranch": {
-          "type": "boolean",
-          "description": "Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI"
-        },
-        "Configuration": {
-          "type": "string",
-          "description": "Configuration to build - Default is 'Debug' (local) or 'Release' (server)",
-          "enum": [
-            "Debug",
-            "Release"
-          ]
-        },
         "Continue": {
           "type": "boolean",
           "description": "Indicates to continue a previously failed build attempt"
@@ -27,33 +76,12 @@
           "description": "Shows the help text for this build assembly"
         },
         "Host": {
-          "type": "string",
           "description": "Host for execution. Default is 'automatic'",
-          "enum": [
-            "AppVeyor",
-            "AzurePipelines",
-            "Bamboo",
-            "Bitbucket",
-            "Bitrise",
-            "GitHubActions",
-            "GitLab",
-            "Jenkins",
-            "Rider",
-            "SpaceAutomation",
-            "TeamCity",
-            "Terminal",
-            "TravisCI",
-            "VisualStudio",
-            "VSCode"
-          ]
+          "$ref": "#/definitions/Host"
         },
         "NoLogo": {
           "type": "boolean",
           "description": "Disables displaying the NUKE logo"
-        },
-        "OCTOVERSION_CurrentBranch": {
-          "type": "string",
-          "description": "Branch name for OctoVersion to use to calculate the version number. Can be set via the environment variable OCTOVERSION_CurrentBranch"
         },
         "Partition": {
           "type": "string",
@@ -78,49 +106,22 @@
           "type": "array",
           "description": "List of targets to be skipped. Empty list skips all dependencies",
           "items": {
-            "type": "string",
-            "enum": [
-              "CalculateVersion",
-              "Clean",
-              "Compile",
-              "CopyToLocalPackages",
-              "Pack",
-              "Restore",
-              "Test"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
-        },
-        "Solution": {
-          "type": "string",
-          "description": "Path to a solution file that is automatically loaded"
         },
         "Target": {
           "type": "array",
           "description": "List of targets to be invoked. Default is '{default_target}'",
           "items": {
-            "type": "string",
-            "enum": [
-              "CalculateVersion",
-              "Clean",
-              "Compile",
-              "CopyToLocalPackages",
-              "Pack",
-              "Restore",
-              "Test"
-            ]
+            "$ref": "#/definitions/ExecutableTarget"
           }
         },
         "Verbosity": {
-          "type": "string",
           "description": "Logging verbosity during build execution. Default is 'Normal'",
-          "enum": [
-            "Minimal",
-            "Normal",
-            "Quiet",
-            "Verbose"
-          ]
+          "$ref": "#/definitions/Verbosity"
         }
       }
     }
-  }
+  },
+  "$ref": "#/definitions/NukeBuild"
 }

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -23,7 +23,7 @@ class Build : NukeBuild
      readonly bool AutoDetectBranch = IsLocalBuild;
 
      [OctoVersion(UpdateBuildNumber = true, BranchParameter = nameof(BranchName),
-         AutoDetectBranchParameter = nameof(AutoDetectBranch), Framework = "net6.0")]
+         AutoDetectBranchParameter = nameof(AutoDetectBranch), Framework = "net8.0")]
      readonly OctoVersionInfo OctoVersionInfo;
 
     AbsolutePath SourceDirectory => RootDirectory / "source";

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -22,8 +22,8 @@ class Build : NukeBuild
      [Parameter("Whether to auto-detect the branch name - this is okay for a local build, but should not be used under CI.")]
      readonly bool AutoDetectBranch = IsLocalBuild;
 
-     [OctoVersion(UpdateBuildNumber = true, BranchParameter = nameof(BranchName),
-         AutoDetectBranchParameter = nameof(AutoDetectBranch), Framework = "net8.0")]
+     [OctoVersion(UpdateBuildNumber = true, BranchMember = nameof(BranchName),
+         AutoDetectBranchMember = nameof(AutoDetectBranch), Framework = "net8.0")]
      readonly OctoVersionInfo OctoVersionInfo;
 
     AbsolutePath SourceDirectory => RootDirectory / "source";

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -10,8 +10,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Nuke.Common" Version="6.1.2" />
-    <PackageDownload Include="OctoVersion.Tool" Version="[0.3.49]" />
+    <PackageReference Include="Nuke.Common" Version="8.1.0" />
+    <PackageReference Include="Octopus.OctoVersion.Tool" Version="0.3.403" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -11,7 +11,7 @@
 
   <ItemGroup>
     <PackageReference Include="Nuke.Common" Version="8.1.0" />
-    <PackageReference Include="Octopus.OctoVersion.Tool" Version="0.3.403" />
+    <PackageReference Include="Octopus.OctoVersion.Tool" Version="0.3.403" ExcludeAssets="all" />
   </ItemGroup>
 
   <ItemGroup>

--- a/build/_build.csproj
+++ b/build/_build.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <NoWarn>CS0649;CS0169</NoWarn>
     <NukeRootDirectory>..</NukeRootDirectory>
     <NukeScriptDirectory>..</NukeScriptDirectory>

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "6.0.301",
+    "version": "8.0.401",
     "rollForward": "latestFeature"
   }
 }

--- a/source/Tests/Tests.csproj
+++ b/source/Tests/Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <AssemblyName>Tests</AssemblyName>
     <RootNamespace>Tests</RootNamespace>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>


### PR DESCRIPTION
Updates the test and support projects in OCL to .NET 8. The library itself is still using .NET Standard 2.1 ([which is supported in .NET 8](https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-1)) so nothing to change there. 

[sc-90700]