### PR TITLE
Added support for setting private properties on an abstract baseclass

### DIFF
--- a/source/Tests/Converters/BlockOclConverterFixture.cs
+++ b/source/Tests/Converters/BlockOclConverterFixture.cs
@@ -52,6 +52,120 @@ namespace Tests.Converters
                 );
         }
 
+        [Test]
+        public void CanGetPropertiesWithNonPublicSettersInAbstractBaseClass()
+        {
+            // Arrange
+            var context = new OclConversionContext(new OclSerializerOptions());
+            var data = new ConcreteImplementation("TestPrivateValue", "TestProtectedValue");
+            // Act
+            var result = (OclBlock)new DefaultBlockOclConverter()
+                .ToElements(context,
+                    typeof(ConcreteImplementation)
+                        .GetProperty(nameof(ConcreteImplementation)),
+                    data)
+                .Single();
+
+            // Assert
+            result.Should()
+                .Be(
+                    new OclBlock("concrete_implementation")
+                    {
+                        new OclAttribute("base_private_property", "TestPrivateValue"),
+                        new OclAttribute("base_protected_property", "TestProtectedValue")
+                    }
+                );
+        }
+
+        [Test]
+        public void CanSetPropertiesWithNonPublicSetters()
+        {
+            // Arrange
+            var context = new OclConversionContext(new OclSerializerOptions());
+            var converter = new DefaultBlockOclConverter();
+
+            // Create an OCL block with a property that corresponds to a private setter in the abstract base class
+            var oclBlock = new OclBlock("class_with_non_public_setter")
+            {
+                new OclAttribute("private_foo", "TestPrivateValue"),
+                new OclAttribute("protected_foo", "TestProtectedValue")
+            };
+
+            // Act
+            var result = converter.FromElement(context, typeof(ClassWithNonPublicSetter), oclBlock, null) as ClassWithNonPublicSetter;
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.PrivateFoo.Should().Be("TestPrivateValue");
+            result!.ProtectedFoo.Should().Be("TestProtectedValue");
+            result!.NoSetter.Should().Be("NoSetterValue");
+        }
+
+        [Test]
+        public void ThrowsExceptionWhenNoSetters()
+        {
+            // Arrange
+            var context = new OclConversionContext(new OclSerializerOptions());
+            var converter = new DefaultBlockOclConverter();
+
+            // Create an OCL block with a property that corresponds to a private setter in the abstract base class
+            var oclBlock = new OclBlock("class_with_non_public_setter")
+            {
+                new OclAttribute("no_setter", "ShouldThrowException"),
+            };
+
+            // Act
+            var ex = Assert.Throws<OclException>(
+                () => converter.FromElement(context, typeof(ClassWithNonPublicSetter), oclBlock, null)
+            );
+            ex.Should().NotBeNull();
+            ex!.Message.Should().Contain("The property 'NoSetter' on 'ClassWithNonPublicSetter' does not have a setter");
+        }
+        
+        [Test]
+        public void ThrowsExceptionWhenNoSettersOnAbstractClass()
+        {
+            // Arrange
+            var context = new OclConversionContext(new OclSerializerOptions());
+            var converter = new DefaultBlockOclConverter();
+
+            // Create an OCL block with a property that corresponds to a private setter in the abstract base class
+            var oclBlock = new OclBlock("concrete_implementation")
+            {
+                new OclAttribute("no_setter", "ShouldThrowException")
+            };
+
+            // Act
+            var ex = Assert.Throws<OclException>(
+                () => converter.FromElement(context, typeof(ConcreteImplementation), oclBlock, null)
+            );
+            ex.Should().NotBeNull();
+            ex!.Message.Should().Contain("The property 'NoSetter' on 'ConcreteImplementation' does not have a setter");
+        }
+
+        [Test]
+        public void CanSetPropertiesWithNonPublicSettersInAbstractBaseClass()
+        {
+            // Arrange
+            var context = new OclConversionContext(new OclSerializerOptions());
+            var converter = new DefaultBlockOclConverter();
+
+            // Create an OCL block with a property that corresponds to a private setter in the abstract base class
+            var oclBlock = new OclBlock("concrete_implementation")
+            {
+                new OclAttribute("base_private_property", "TestPrivateValue"),
+                new OclAttribute("base_protected_property", "TestProtectedValue")
+            };
+
+            // Act
+            var result = converter.FromElement(context, typeof(ConcreteImplementation), oclBlock, null) as ConcreteImplementation;
+
+            // Assert
+            result.Should().NotBeNull();
+            result!.BasePrivateProperty.Should().Be("TestPrivateValue");
+            result!.BaseProtectedProperty.Should().Be("TestProtectedValue");
+        }
+
         class WithIndexer
         {
             public string MyProp => "MyValue";
@@ -61,6 +175,54 @@ namespace Tests.Converters
         class Dummy
         {
             public object? Foo { get; set; }
+        }
+
+        class ClassWithNonPublicSetter
+        {
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public string? PrivateFoo { get; private set; }
+
+            // ReSharper disable once UnusedAutoPropertyAccessor.Local
+            public string? ProtectedFoo { get; protected set; }
+
+            public string? NoSetter { get; } = "NoSetterValue";
+        }
+
+        // Test classes for abstract base class scenario
+        public abstract class AbstractBase
+        {
+            // ReSharper disable once ConvertToPrimaryConstructor
+            protected AbstractBase(string? basePrivateProperty, string? baseProtectedProperty)
+            {
+                // Initialize properties in the constructor
+                BasePrivateProperty = basePrivateProperty ?? string.Empty;
+                BaseProtectedProperty = baseProtectedProperty ?? string.Empty;
+            }
+
+            // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+            public string BasePrivateProperty { get; private set; }
+
+            // ReSharper disable once AutoPropertyCanBeMadeGetOnly.Local
+            public string BaseProtectedProperty { get; private set; }
+            
+            public string? NoSetter { get; } = null;
+        }
+
+        public class ConcreteImplementation : AbstractBase
+        {
+            // Parameterless constructor for OCL converter
+            public ConcreteImplementation()
+                : base(string.Empty, string.Empty)
+            {
+            }
+
+            // This class inherits BaseProperties but the setter is private or protected in the base class
+            // The OclConverter should still be able to set it via reflection
+            // ReSharper disable once ConvertToPrimaryConstructor
+            public ConcreteImplementation(string? basePrivateProperty, string? baseProtectedProperty)
+                : base(basePrivateProperty, baseProtectedProperty)
+            {
+            }
         }
     }
 }


### PR DESCRIPTION
# Background

In converting some classes to use 'private' setters instead of 'protected' i ran into the following issue with `ProjectVariables`
```
Octopus.Client.Exceptions.OctopusValidationException : There was a problem with your request.

 - There was an error trying to parse the file '.octopus/variables.ocl' on the 'branch-a0194fcb' branch. 
   Please check that the OCL is valid. 
   The property 'Variables' on 'ProjectVariables' does not have a setter
```

This is because:  `ProjectVariables` inherits from a `abstract class VariableSet`.


The OCL Converter `if (!propertyToSet.CanWrite)` was returning 'false', in this case.

> [CanWrite](https://learn.microsoft.com/en-us/dotnet/api/system.reflection.propertyinfo.canwrite?view=net-9.0) returns true if the property has a set accessor, even if the accessor is private, internal (or Friend in Visual Basic), or protected. If the property does not have a set accessor, the method returns false.

However, because its being applied on a property from a derived class, it is not finding the private setters that are defined on the base class.

# Result

We have updated the SetProperties to now support this use case and have added tests to cover it as well as other tests to handle the throwing of exceptions when there is nothing to set and also regression tests to cover non-base class implementations. 


